### PR TITLE
Refactor deepFreeze Type annotations

### DIFF
--- a/docs/deepFreeze.md
+++ b/docs/deepFreeze.md
@@ -19,10 +19,13 @@ Call `Object.freeze(obj)` recursively on all properties, checking if each one is
 Finally, use `Object.freeze()` to freeze the given object.
 
 ```ts title="typescript"
-const deepFreeze = (obj: any) => {
+const deepFreeze = <T extends object>(obj: T) => {
   Object.keys(obj).forEach((prop) => {
-    if (typeof obj[prop] === "object" && !Object.isFrozen(obj[prop])) {
-      deepFreeze(obj[prop]);
+    if (
+      typeof obj[prop as keyof T] === 'object' &&
+      !Object.isFrozen(obj[prop as keyof T])
+    ) {
+      deepFreeze(obj[prop as keyof T]);
     }
   });
   return Object.freeze(obj);


### PR DESCRIPTION
Updated deepFreeze function Type annotations to use a generic instead of any for better type checking - ensures that only objects are passed to the function.